### PR TITLE
Fix assertion error

### DIFF
--- a/flask_github.py
+++ b/flask_github.py
@@ -166,10 +166,8 @@ class GitHub(object):
 
         status_code = str(response.status_code)
 
-        if status_code.startswith('4'):
+        if not status_code.startswith('2'):
             raise GitHubError(response)
-
-        assert status_code.startswith('2')
 
         if response.headers['Content-Type'].startswith('application/json'):
             return response.json()


### PR DESCRIPTION
When GitHub returns a temporary 503 error, the extension currently
raises an assertion error, which is not the expected result from an
extension.

With this change, all non-2xx responses will raise a GitHubError, not
just 4xx.
