### PR TITLE
No content-type from github api results in key error

### DIFF
--- a/flask_github.py
+++ b/flask_github.py
@@ -172,7 +172,7 @@ class GitHub(object):
         if not status_code.startswith('2'):
             raise GitHubError(response)
 
-        if response.headers['Content-Type'].startswith('application/json'):
+        if 'Content-Type' in response.headers and response.headers['Content-Type'].startswith('application/json'):
             result = response.json()
             while response.links.get('next') and all_pages:
                 response = self.session.request(


### PR DESCRIPTION
>`DELETE /repos/:owner/:repo/hooks/:id`

>**Response**
>```
Status: 204 No Content
X-RateLimit-Limit: 5000
X-RateLimit-Remaining: 4999
```
https://developer.github.com/v3/repos/hooks/#delete-a-hook

This request does not give content back, hence the need of checking there is Content-Type in headers