### PR TITLE
fixed is_json_response bug (failed to account for charset in response)

### DIFF
--- a/flask_github.py
+++ b/flask_github.py
@@ -46,7 +46,8 @@ def is_json_response(response):
     :returns: ``True`` if ``response`` is JSON, ``False`` otherwise
     :rtype bool:
     """
-    return response.headers.get('Content-Type', '') == 'application/json'
+    content_type = response.headers.get('Content-Type', '')
+    return content_type == 'application/json' or content_type.startswith('application/json;')
 
 
 class GitHubError(Exception):


### PR DESCRIPTION
The response from the GitHub API for 'GET user' had the Content-Type of "application/json; charset=utf-8". The is_json_response method failed to account for the charset appendage, resulting in the json never being returned by the GitHub object. 