### PR TITLE
Copy the headers so the access token doesn't leak

### DIFF
--- a/flask_github.py
+++ b/flask_github.py
@@ -224,6 +224,7 @@ class GitHub(object):
         kwargs.setdefault('headers', {})
         if access_token is None:
             access_token = self.get_access_token()
+        kwargs['headers'] = kwargs['headers'].copy()
         kwargs['headers'].setdefault('Authorization', 'token %s' % access_token)
 
         if resource.startswith(("http://", "https://")):


### PR DESCRIPTION
The way the headers kwarg is currently modified will inject the access token into the argument, modifying the input. I found that this was unexpected (it ended up getting logged somewhere) so I think this should probably be copied before modifying it.